### PR TITLE
Update TestBed configs with missing declarations, imports and providers

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,16 +1,17 @@
 import { TestBed, async } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+
 import { AppComponent } from './app.component';
+import { BoardComponent } from './board/board.component';
+import { NbLayoutModule } from '@nebular/theme';
+import { NebularTestingModule } from './nebular-testing.module';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SquareComponent } from './square/square.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
-      ],
+      imports: [NbLayoutModule, NebularTestingModule, RouterTestingModule],
+      declarations: [AppComponent, BoardComponent, SquareComponent]
     }).compileComponents();
   }));
 
@@ -24,12 +25,5 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('myapp');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('myapp app is running!');
   });
 });

--- a/src/app/board/board.component.spec.ts
+++ b/src/app/board/board.component.spec.ts
@@ -1,6 +1,7 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
 import { BoardComponent } from './board.component';
+import { SquareComponent } from '../square/square.component';
 
 describe('BoardComponent', () => {
   let component: BoardComponent;
@@ -8,9 +9,8 @@ describe('BoardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BoardComponent ]
-    })
-    .compileComponents();
+      declarations: [BoardComponent, SquareComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/nebular-testing.module.ts
+++ b/src/app/nebular-testing.module.ts
@@ -1,0 +1,43 @@
+import {
+  BUILT_IN_THEMES,
+  DEFAULT_MEDIA_BREAKPOINTS,
+  NB_BUILT_IN_JS_THEMES,
+  NB_DOCUMENT,
+  NB_JS_THEMES,
+  NB_MEDIA_BREAKPOINTS,
+  NB_THEME_OPTIONS,
+  NB_WINDOW,
+  NbJSThemesRegistry,
+  NbLayoutDirectionService,
+  NbLayoutRulerService,
+  NbLayoutScrollService,
+  NbMediaBreakpointsService,
+  NbOverlayContainerAdapter,
+  NbSpinnerService,
+  NbThemeService
+} from '@nebular/theme';
+
+import { NgModule } from '@angular/core';
+
+@NgModule({
+  providers: [
+    NbThemeService,
+    // Required by NbThemeService
+    NbMediaBreakpointsService,
+    { provide: NB_THEME_OPTIONS, useValue: { name: 'default' } },
+    { provide: NB_MEDIA_BREAKPOINTS, useValue: DEFAULT_MEDIA_BREAKPOINTS },
+    { provide: NB_JS_THEMES, useValue: [] },
+    { provide: NB_BUILT_IN_JS_THEMES, useValue: BUILT_IN_THEMES },
+    NbJSThemesRegistry,
+    // NbSpinnerService
+    NbSpinnerService,
+    // Required by NbLayoutComponent
+    { provide: NB_DOCUMENT, useValue: document },
+    { provide: NB_WINDOW, useValue: window },
+    NbLayoutDirectionService,
+    NbLayoutScrollService,
+    NbLayoutRulerService,
+    NbOverlayContainerAdapter
+  ]
+})
+export class NebularTestingModule {}


### PR DESCRIPTION
Resolves #1

The errors detailed in https://github.com/fireship-io/angular-tic-tac-toe/issues/1 indicate that components, modules or services are missing from the TestBed configurations.

In short, the Angular TestBed makes zero assumptions, and needs you to wire in all child components as declarations, any dependent modules you need to import (like routers, layout modules, etc) and any Dependency Injected services as providers.  Doing this for the components and services you write in your own app is fairly easy, but sometimes you inherit some messy configurations from third-party libraries.

In this case, the use of the Nebular UI means there's a load of extra stuff you need to provide in order for that to work in your testing environment.  I found some examples of how the Nebular dev team [tests their own stuff](https://github.com/akveo/nebular/blob/4d66419ea89260d9e1359bb6c74a26a47c67d159/src/framework/theme/services/theme.spec.ts) and borrowed some of their strategies.  Once I had this working in the `app.component.spec.ts` file, I moved the majority into a separate module (`nebular-testing.module.ts` so it is easily packaged and re-usable across any of your future spec files.

Hopefully, this unblocks your testing efforts.  If you have any other Angular or testing related questions, please don't hesitate to reach out here or [on twitter](http://twitter.com/brendoncaulkins).