### PR TITLE
remove outline and box shadow after selection

### DIFF
--- a/src/app/square/square.component.ts
+++ b/src/app/square/square.component.ts
@@ -7,7 +7,7 @@ import { Component, Input } from '@angular/core';
     <button nbButton hero status="success" *ngIf="value == 'X'">{{ value }}</button>
     <button nbButton hero status="info" *ngIf="value == 'O'">{{ value }}</button>
   `,
-  styles: ['button { width: 100%; height: 100%; font-size: 5em !important; }']
+  styles: ['button { width: 100%; height: 100%; font-size: 5em !important; outline: none !important; box-shadow: none !important  }']
 })
 export class SquareComponent  {
 


### PR DESCRIPTION
I noticed on your video going over this, that an outline and box shadow are placed on the next button after a move is made. It's a simple fix, just force those two to not appear.